### PR TITLE
GKN-186: Подключить aphrodite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1545,6 +1545,16 @@
         "normalize-path": "^2.1.1"
       }
     },
+    "aphrodite": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/aphrodite/-/aphrodite-2.4.0.tgz",
+      "integrity": "sha512-1rVRlLco+j1YAT5aKEE8Wuw5zWV+tI41/quEheJAG0vNaGHE64iJ/a2SiVMz8Uc80VdP2/Hjlfd2bPJOWsqJuQ==",
+      "requires": {
+        "asap": "^2.0.3",
+        "inline-style-prefixer": "^5.1.0",
+        "string-hash": "^1.1.3"
+      }
+    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -3006,6 +3016,15 @@
         "public-encrypt": "^4.0.0",
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
+      }
+    },
+    "css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
       }
     },
     "css-loader": {
@@ -5717,6 +5736,11 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "hyphenate-style-name": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz",
+      "integrity": "sha512-EcuixamT82oplpoJ2XU4pDtKGWQ7b00CD9f1ug9IaQ3p1bkHMiKCZ9ut9QDI6qsa6cpUuB+A/I+zLtdNK4n2DQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5883,6 +5907,14 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "inline-style-prefixer": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-5.1.0.tgz",
+      "integrity": "sha512-giteQHPMrApQOSjNSjteO5ZGSGMRf9gas14fRy2lg2buSc1nRnj6o6xuNds5cMTKrkncyrTu3gJn/yflFMVdmg==",
+      "requires": {
+        "css-in-js-utils": "^2.0.0"
+      }
     },
     "inquirer": {
       "version": "6.5.0",
@@ -9228,6 +9260,11 @@
       "requires": {
         "stream-to": "~0.2.0"
       }
+    },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "string-width": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
+    "aphrodite": "^2.4.0",
     "autoprefixer": "^9.7.1",
     "axios": "^0.18.0",
     "babel-loader": "^8.0.4",

--- a/src/v2/aphrodite.js
+++ b/src/v2/aphrodite.js
@@ -1,0 +1,14 @@
+import { StyleSheet as Aphrodite } from 'aphrodite/no-important';
+
+const aphrodite = Aphrodite.extend([{
+  selectorHandler: (selector, baseSelector, generateSubtreeStyles) => {
+    if (selector[0] === '>') {
+      const tag = selector.slice(1);
+      const nestedTag = generateSubtreeStyles(`${baseSelector} ${tag}`);
+      return nestedTag;
+    }
+    return null;
+  },
+}]);
+
+export const { StyleSheet, css } = aphrodite;


### PR DESCRIPTION
По сравнению с дефолтным использованием aphrodite есть два отличия (ради которых и сделан файл `src/v2/aphrodite.js`:

1. Дефолтный !important отключен (см. ридми на странице проекта).
2. Написан небольшой плагин, позволяющий использовать css-подобные вложенные стили (типа 'div, находящийся в table', например: table > div).