### PR TITLE
GF-188: При запросе списка трасс не запрашивать пролазы

### DIFF
--- a/src/v2/components/RouteCard/RouteCard.js
+++ b/src/v2/components/RouteCard/RouteCard.js
@@ -2,14 +2,11 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import * as R from 'ramda';
 import moment from 'moment';
 import { SOON_END_PERIOD } from '@/v1/Constants/Route';
 import RouteStatus from '../RouteStatus/RouteStatus';
 import { timeFromNow } from '@/v1/Constants/DateTimeFormatter';
 import RouteContext from '@/v1/contexts/RouteContext';
-import { avail, notAvail } from '@/v1/utils';
-import getArrayFromObject from '@/v1/utils/getArrayFromObject';
 import { css } from '../../aphrodite';
 import styles from './styles';
 
@@ -25,16 +22,11 @@ class RouteCard extends Component {
 
   render() {
     moment.locale('ru');
-    const { route, user } = this.props;
+    const { route } = this.props;
     const { imageIsLoading } = this.state;
     const date = moment().add(SOON_END_PERIOD, 'days');
     const installedUntil = route.installed_until ? moment(route.installed_until) : null;
-    const ascents = avail(route.ascents) && getArrayFromObject(route.ascents);
-    const ascent = (
-      notAvail(user) || notAvail(ascents)
-        ? null
-        : (R.find(R.propEq('user_id', user.id))(ascents))
-    );
+    const { ascent_result: ascentResult } = route;
     let year;
     let titleDate;
     if (route.installed_until) {
@@ -46,9 +38,17 @@ class RouteCard extends Component {
     const alarmIcon = `${cardSprite}#icon-alarm`;
     const clockIcon = `${cardSprite}#icon-clock`;
     const installedUntilValid = (installedUntil && date >= installedUntil);
+    const ascentIsSuccess = ascentResult && ascentResult !== 'unsuccessful';
     return (
       <RouteContext.Provider value={{ route }}>
-        <a className={css(styles.routeCard, (ascent && ascent.result !== 'unsuccessful') ? styles.routeCardDone : '')}>
+        <a
+          className={
+            css(
+              styles.routeCard,
+              ascentIsSuccess && styles.routeCardDone,
+            )
+          }
+        >
           <article className={css(styles.routeCardInner)}>
             <div className={css(styles.routeCardImage)}>
               <div className={css(styles.routeCardImageInner)}>
@@ -63,7 +63,7 @@ class RouteCard extends Component {
                   )
                   }
                 {
-                  (ascent && ascent.result !== 'unsuccessful') && (
+                  ascentIsSuccess && (
                     <div className={css(styles.routeCardTrackStatus)}>
                       <RouteStatus />
                     </div>

--- a/src/v2/components/RouteStatus/RouteStatus.js
+++ b/src/v2/components/RouteStatus/RouteStatus.js
@@ -1,31 +1,20 @@
 import React from 'react';
-import { withRouter } from 'react-router-dom';
-import { connect } from 'react-redux';
-import * as R from 'ramda';
 import PropTypes from 'prop-types';
-import { notAvail, avail } from '@/v1/utils';
 import RouteContext from '@/v1/contexts/RouteContext';
-import getArrayFromObject from '@/v1/utils/getArrayFromObject';
 import { StyleSheet, css } from '../../aphrodite';
 
-
-const RouteStatus = ({ onClick, user }) => (
+const RouteStatus = ({ onClick }) => (
   <RouteContext.Consumer>
     {
       ({ route }) => {
-        const ascents = avail(route.ascents) && getArrayFromObject(route.ascents);
-        const ascent = (
-          notAvail(user) || notAvail(ascents)
-            ? null
-            : (R.find(R.propEq('user_id', user.id))(ascents))
-        );
-        const complete = (ascent && ascent.result !== 'unsuccessful');
+        const { ascent_result: ascentResult } = route;
+        const complete = (ascentResult && ascentResult !== 'unsuccessful');
 
         let statusClassRedpoint = false;
         let statusClassFlash = false;
-        if (complete && ascent.result === 'red_point') {
+        if (complete && ascentResult === 'red_point') {
           statusClassRedpoint = true;
-        } else if (complete && ascent.result === 'flash') {
+        } else if (complete && ascentResult === 'flash') {
           statusClassFlash = true;
         }
         return (
@@ -44,7 +33,7 @@ const RouteStatus = ({ onClick, user }) => (
             {
               complete
                 ? (
-                  ascent.result === 'red_point' ? 'Пролез' : 'Флешанул'
+                  ascentResult === 'red_point' ? 'Пролез' : 'Флешанул'
                 )
                 : 'Не пройдена'
             }
@@ -94,17 +83,8 @@ const styles = StyleSheet.create({
   },
 });
 
-RouteStatus.propTypes = {
-  user: PropTypes.object,
-  onClick: PropTypes.func,
-};
+RouteStatus.propTypes = { onClick: PropTypes.func };
 
-RouteStatus.defaultProps = {
-  onClick: null,
-};
+RouteStatus.defaultProps = { onClick: null };
 
-const mapStateToProps = state => ({
-  user: state.usersStore.users[state.usersStore.currentUserId],
-});
-
-export default withRouter(connect(mapStateToProps)(RouteStatus));
+export default RouteStatus;

--- a/src/v2/redux/routes/actions.js
+++ b/src/v2/redux/routes/actions.js
@@ -11,7 +11,8 @@ export const acts = {
   LOAD_ROUTES_SUCCESS: 'LOAD_ROUTES_SUCCESS_V2',
   LOAD_ROUTE_SUCCESS: 'LOAD_ROUTE_SUCCESS_V2',
   LOAD_ROUTE_DATA_SUCCESS: 'LOAD_ROUTE_DATA_SUCCESS_V2',
-  LOAD_ROUTE_PROPERTY_SUCCESS: 'LOAD_ROUTE_PROPERTY_SUCCESS_V2',
+  LOAD_ROUTE_PROPERTY: 'LOAD_ROUTE_PROPERTY_V2',
+  LOAD_ROUTE_PROPERTY_BY_ID_SUCCESS: 'LOAD_ROUTE_PROPERTY_BY_ID_SUCCESS_V2',
   REMOVE_ROUTE_PROPERTY_BY_ID_SUCCESS: 'REMOVE_ROUTE_PROPERTY_BY_ID_SUCCESS_V2',
   REMOVE_ROUTE_SUCCESS: 'REMOVE_ROUTE_SUCCESS_V2',
   LOAD_FILTRATION_RESULTS: 'LOAD_FILTRATION_RESULTS_V2',
@@ -71,16 +72,12 @@ const prepareAllRoutes = routes => (
 
 export const loadRoutes = (url, params) => (
   (dispatch) => {
-    dispatch({
-      type: acts.LOAD_ROUTES_REQUEST,
-    });
+    dispatch({ type: acts.LOAD_ROUTES_REQUEST });
 
-    const paramsCopy = R.clone(params);
-    paramsCopy.with = ['ascents'];
     Api.get(
       url,
       {
-        params: paramsCopy,
+        params,
         success(payload, metadata) {
           const routeIds = R.map(route => route.id, payload);
           const numOfPages = Math.max(
@@ -282,7 +279,7 @@ export const addLike = (params, afterAll) => (
         method: 'post',
         success(payload) {
           dispatch({
-            type: acts.LOAD_ROUTE_PROPERTY_SUCCESS,
+            type: acts.LOAD_ROUTE_PROPERTY_BY_ID_SUCCESS,
             routeId: payload.route_id,
             routePropertyName: 'likes',
             routePropertyData: payload,
@@ -304,9 +301,7 @@ export const addLike = (params, afterAll) => (
 
 export const addAscent = (params, afterSuccess) => (
   (dispatch) => {
-    dispatch({
-      type: acts.LOAD_ROUTES_REQUEST,
-    });
+    dispatch({ type: acts.LOAD_ROUTES_REQUEST });
 
     Api.post(
       '/v1/ascents',
@@ -316,17 +311,21 @@ export const addAscent = (params, afterSuccess) => (
         type: 'form-multipart',
         success(payload) {
           dispatch({
-            type: acts.LOAD_ROUTE_PROPERTY_SUCCESS,
+            type: acts.LOAD_ROUTE_PROPERTY_BY_ID_SUCCESS,
             routeId: payload.route_id,
             routePropertyName: 'ascents',
             routePropertyData: payload,
           });
-          afterSuccess();
+          dispatch({
+            type: acts.LOAD_ROUTE_PROPERTY,
+            routeId: payload.route_id,
+            routePropertyName: 'ascent_result',
+            routePropertyValue: payload.result,
+          });
+          afterSuccess && afterSuccess();
         },
         failed(error) {
-          dispatch({
-            type: acts.LOAD_ROUTES_FAILED,
-          });
+          dispatch({ type: acts.LOAD_ROUTES_FAILED });
 
           toastHttpError(error);
         },
@@ -337,9 +336,7 @@ export const addAscent = (params, afterSuccess) => (
 
 export const updateAscent = (id, params, afterSuccess) => (
   (dispatch) => {
-    dispatch({
-      type: acts.LOAD_ROUTES_REQUEST,
-    });
+    dispatch({ type: acts.LOAD_ROUTES_REQUEST });
 
     Api.post(
       `/v1/ascents/${id}`,
@@ -349,17 +346,21 @@ export const updateAscent = (id, params, afterSuccess) => (
         type: 'form-multipart',
         success(payload) {
           dispatch({
-            type: acts.LOAD_ROUTE_PROPERTY_SUCCESS,
+            type: acts.LOAD_ROUTE_PROPERTY_BY_ID_SUCCESS,
             routeId: payload.route_id,
             routePropertyName: 'ascents',
             routePropertyData: payload,
           });
-          afterSuccess();
+          dispatch({
+            type: acts.LOAD_ROUTE_PROPERTY,
+            routeId: payload.route_id,
+            routePropertyName: 'ascent_result',
+            routePropertyValue: payload.result,
+          });
+          afterSuccess && afterSuccess();
         },
         failed(error) {
-          dispatch({
-            type: acts.LOAD_ROUTES_FAILED,
-          });
+          dispatch({ type: acts.LOAD_ROUTES_FAILED });
 
           toastHttpError(error);
         },
@@ -382,12 +383,18 @@ export const removeAscent = (id, afterSuccess) => (
             routePropertyName: 'ascents',
             routePropertyId: payload.id,
           });
-          afterSuccess();
+          dispatch({
+            type: acts.LOAD_ROUTE_PROPERTY,
+            routeId: payload.route_id,
+            routePropertyName: 'ascent_result',
+            routePropertyValue: null,
+          });
+          afterSuccess && afterSuccess();
         },
         failed(error) {
-          dispatch({
-            type: acts.LOAD_ROUTES_FAILED,
-          });
+          dispatch({ type: acts.LOAD_ROUTES_FAILED });
+
+          toastHttpError(error);
         },
       },
     );

--- a/src/v2/redux/routes/reducer.js
+++ b/src/v2/redux/routes/reducer.js
@@ -52,7 +52,16 @@ const routesStoreReducer = (
       ),
       numOfActiveRequests: state.numOfActiveRequests - 1,
     };
-  case acts.LOAD_ROUTE_PROPERTY_SUCCESS:
+  case acts.LOAD_ROUTE_PROPERTY:
+    return {
+      ...state,
+      routes: R.mergeDeepRight(
+        state.routes,
+        { [action.routeId]: { [action.routePropertyName]: action.routePropertyValue } },
+      ),
+      numOfActiveRequests: state.numOfActiveRequests - 1,
+    };
+  case acts.LOAD_ROUTE_PROPERTY_BY_ID_SUCCESS:
     return {
       ...state,
       routes: R.mergeDeepRight(


### PR DESCRIPTION
В итоге отказались от идеи сохранять пролазы в локальный state, так как пролазы итак сохраняются в глобальный при запросе отдельных трасс, а обращение к пролазам происходит в нескольких компонентах, использование для хранения пролазов глобального состояния удобнее