### PR TITLE
GF-205: В Firefox съезжает отображение маркеров при редактировании

### DIFF
--- a/src/v2/components/Marker/Marker.js
+++ b/src/v2/components/Marker/Marker.js
@@ -40,6 +40,9 @@ export default class Marker extends Component {
       return (
         <div
           draggable={false}
+          // Fixes dragging pointers on Firefox (see
+          // https://stackoverflow.com/questions/26356877/html5-draggable-false-not-working-in-firefox-browser)
+          onDragStart={(e) => { e.preventDefault() }}
           className={css(styles.marker)}
           style={{
             left: `calc(${left + dx}% - ${radius - this.xShift()}px)`,
@@ -48,6 +51,9 @@ export default class Marker extends Component {
         >
           <img
             draggable={false}
+            // Fixes dragging pointers on Firefox (see
+            // https://stackoverflow.com/questions/26356877/html5-draggable-false-not-working-in-firefox-browser)
+            onDragStart={(e) => { e.preventDefault() }}
             src={require('./images/hold-mark.png')}
             className={css(styles.markerImage)}
             style={{


### PR DESCRIPTION
Firefox игнорирует draggable={false}, поэтому при перетаскивании маркера он обрабатывается как draggable=true, если гуглить, то для firefox предлагается в качестве решения сделать onDragStart={(e) => { e.preventDefault() }} Вроде такой вариант работает

https://stackoverflow.com/questions/26356877/html5-draggable-false-not-working-in-firefox-browser
https://stackoverflow.com/questions/3873595/how-to-disable-firefoxs-default-drag-and-drop-on-all-images-behavior-with-jquer

Есть еще вариант с прописыванием css стиля -webkit-user-drag: none; /* Prevents dragging of images/divs etc */, но на практике это не помогает, на стрелку все равно срабатывает drag