### PR TITLE
GF-211: Fix marker position for different screen size (firefox)

### DIFF
--- a/src/v2/components/RoutesEditModal/RoutesEditModal.js
+++ b/src/v2/components/RoutesEditModal/RoutesEditModal.js
@@ -750,12 +750,13 @@ const styles = StyleSheet.create({
   },
   modalTrack: {
     width: '100%',
-    height: 'calc(100% - 70px)',
+    height: 'calc(100% - 104px)',
     backgroundColor: '#F3F3F3',
     overflow: 'hidden',
     display: 'block',
     alignItems: 'center',
     position: 'relative',
+    '@media screen and (max-width: 1440px)': { height: 'calc(100% - 70px)' },
   },
   modalTrackDescr: {
     position: 'absolute',


### PR DESCRIPTION
Проблема была в том, что при переходе размера экрана через 1440px, меняется высота блока с кнопками с 70px на 104px, который под изображением, поэтому высота блока с изображением оказывается неправильной, добавила учет этого через media screen