### PR TITLE
GF-215: При добавлении пролазов календарь скрывается за нижней границей окна

### DIFF
--- a/src/v2/components/common/Calendar/Calendar.js
+++ b/src/v2/components/common/Calendar/Calendar.js
@@ -133,7 +133,10 @@ export default class DatePicker extends Component {
 
   render() {
     return (
-      <div className="modal__table-item-calendar">
+      <div
+        className="modal__table-item-calendar"
+        style={this.props.left && { left: this.props.left }}
+      >
         <div className="calendar calendar_left_v2">
           <div className="calendar__header" />
           <div className="calendar__content">
@@ -209,6 +212,7 @@ DatePicker.propTypes = {
   date: PropTypes.string,
   hide: PropTypes.func,
   onSelect: PropTypes.func.isRequired,
+  left: PropTypes.string,
 };
 
 DatePicker.defaultProps = {

--- a/src/v2/forms/RouteAscents/RouteAscentsTable/RouteAscentsTableLayout.jsx
+++ b/src/v2/forms/RouteAscents/RouteAscentsTable/RouteAscentsTableLayout.jsx
@@ -53,32 +53,37 @@ const RouteAscentsTableLayout = ({
                         tabIndex={0}
                         style={{
                           width: '45%',
-                          position: 'absolute',
                           cursor: 'pointer',
                           outline: 'none',
+                          whiteSpace: 'nowrap',
                         }}
                         onClick={() => {
                           onDateClicked && onDateClicked(ascent.id);
                         }}
                       >
                         {ascent.accomplished_at}
+
                         {
                           dateChangingAscentId === ascent.id && (
-                            <Calendar
-                              date={ascent.accomplished_at}
-                              onSelect={
-                                (newDate) => {
-                                  onDateSelected && onDateSelected(
-                                    ascent.id,
-                                    newDate ? newDate : null,
-                                  );
+                            <div style={{ position: 'relative' }}>
+                              <Calendar
+                                left="-80px"
+                                date={ascent.accomplished_at}
+                                onSelect={
+                                  (newDate) => {
+                                    onDateSelected && onDateSelected(
+                                      ascent.id,
+                                      newDate ? newDate : null,
+                                    );
+                                  }
                                 }
-                              }
-                            />
+                              />
+                            </div>
                           )
                         }
+
                       </td>
-                      <td tabIndex={0} style={{ paddingLeft: '45%', outline: 'none' }}>
+                      <td tabIndex={0} style={{ outline: 'none' }}>
                         {
                           ascent.count > 1 && `×${ascent.count}`
                         }
@@ -120,6 +125,7 @@ const style = StyleSheet.create({
   table: {
     width: '100%',
     borderSpacing: 0,
+    tableLayout: 'fixed',
 
     '> tbody': {
       '> tr': {


### PR DESCRIPTION
Текущее решение не претендует на аккуратное, но по идее оно должно решить две проблемы, которые сейчас есть
1) При прокрутке даты съезжают относительно таблицы
2) Календарь может выходить за границы страницы

Сделала так, что календарь появляется в рамках того же скролла, который есть у таблицы, причем календарь появляется смещенный влево относительно поля с датой под ней (а не как было выровнено по левому краю) При этом не появляется горизонтального скролла, только вертикальный, если нужен

На мой взгляд недостатки такого решения:
1) если открыть календарь для какой-нибудь из нижних строк, то под таблицей появляется пустое пространство, на мой взгляд внешне это не очень хорошо выглядит
2) если открыть календарь для какой-нибудь из нижних строк, то он может открыться вниз так, что пользователь этого не увидит, хотелось бы чтобы при этом выполнялась прокрутка вниз

Мне кажется, что более аккуратным решением будет, если сделать так, что календарь будет появляться как бы следующей строкой таблицы, т.е. кликаем по дате, появляется строчка ниже, внутри которой календарь. Проблема этого решения в том, что таблица сделана "полосатая" и появление такой строчки сбивает эту "полосатость", в смысле того, что все строчки ниже той, которую развернули будут менять цвет на противоположенный