### PR TITLE
GF-224: При задании положения трассы отображать трассы на момент даты накрутки трассы

### DIFF
--- a/src/v2/components/RoutesShowModal/RoutesShowModal.js
+++ b/src/v2/components/RoutesShowModal/RoutesShowModal.js
@@ -14,7 +14,7 @@ import RouteDataTable from '@/v1/components/RouteDataTable/RouteDataTable';
 import RouteEditor from '@/v1/components/RouteEditor/RouteEditor';
 import CloseButton from '@/v1/components/CloseButton/CloseButton';
 import { DEFAULT_COMMENTS_DISPLAYED } from '@/v1/Constants/Comments';
-import SchemeModal from '@/v1/components/SchemeModal/SchemeModal';
+import SchemeModal from '@/v2/components/SchemeModal/SchemeModal';
 import ShowSchemeButton from '@/v1/components/ShowSchemeButton/ShowSchemeButton';
 import NoticeButton from '@/v1/components/NoticeButton/NoticeButton';
 import NoticeForm from '@/v1/components/NoticeForm/NoticeForm';

--- a/src/v2/components/SchemeModal/SchemeModal.js
+++ b/src/v2/components/SchemeModal/SchemeModal.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import moment from 'moment';
 import Axios from 'axios';
 import * as R from 'ramda';
+import dayjs from 'dayjs';
 import Scheme from '../Scheme/Scheme';
 import BackButton from '../BackButton/BackButton';
 import { StyleSheet, css } from '../../aphrodite';
@@ -35,7 +35,10 @@ class SchemeModal extends Component {
     const currentSectorId = currentRoute.sector_id;
     const currentCategoryFrom = DEFAULT_FILTERS.categoryFrom;
     const currentCategoryTo = DEFAULT_FILTERS.categoryTo;
-    const currentDate = DEFAULT_FILTERS.date;
+    const lastActiveDay = dayjs(currentRoute.installed_until).subtract(1, 'days');
+    const currentDate = (
+      currentRoute.installed_at || lastActiveDay || DEFAULT_FILTERS.date
+    );
     const params = {
       filters: {
         category: [[currentCategoryFrom], [currentCategoryTo]],
@@ -44,9 +47,9 @@ class SchemeModal extends Component {
       },
     };
 
-    params.filters.installed_at = [[null], [moment(currentDate).format(BACKEND_DATE_FORMAT)]];
+    params.filters.installed_at = [[null], [dayjs(currentDate).format(BACKEND_DATE_FORMAT)]];
     params.filters.installed_until = [
-      [moment(currentDate).add(1, 'days').format(BACKEND_DATE_FORMAT)],
+      [dayjs(currentDate).add(1, 'days').format(BACKEND_DATE_FORMAT)],
       [null],
     ];
     Axios.get(`${ApiUrl}/v1/sectors/${currentSectorId}/routes`, { params })


### PR DESCRIPTION
1. Отображение схемы с трассами в окнах просмотра/редактирования реализует компонент SchemeModal. При этом RoutesShowModal использовал этот компонент из v1, а RoutesEditModal из v2. Я предположила, что оба должны использовать из v2, поэтому переключила на него. Если это так, то логичнее удалить из v1 SchemeModal, так как этот компонент больше нигде не используется и RouteEditModal из v1 тоже можно удалить, так как он сейчас не используется, вопрос уместно ли это сделать в этом тикете или лучше отдельным?
2. Переключила moment на dayjs для компонента SchemeModal, это не имеет прямого отношения к тикету, просто попутная правка
3. Для некоторых трасс заполнена только дата скрутки, возможно имеет смысл сделать так, чтобы если есть дата накрутки, то отображаются трассы на момент накрутки, если ее нет, но есть дата скрутки, то трассы на момент скрутки, если нет ни того, ни другого, то на текущую дату. По идее положение трассы на момент скрутки будет более информативным, нежели скрученная трасса поверх трасс, которые есть на текущую дату