### PR TITLE
GF-226: Незалогиненному юзеру показывают фильтр «Понравившиеся мне»

### DIFF
--- a/src/v1/components/FilterBlock/FilterBlock.js
+++ b/src/v1/components/FilterBlock/FilterBlock.js
@@ -194,7 +194,7 @@ class FilterBlock extends Component {
       filters,
     } = getMergedFilters(selectedFilters, this.state.filtersList, spotId, sectorId);
     const defaultFilters = R.filter(
-      e => !R.contains(e.id, R.keys(RESULT_FILTERS)),
+      e => !R.contains(e.id, R.concat(R.keys(RESULT_FILTERS), ['liked'])),
       filters,
     );
     const currentFilters = (


### PR DESCRIPTION
Данная правка скрывает фильтр понравившиеся мне для незалогинненных юзеров по аналогии с тем, как сделано для фильтров пролез, флешанул итд., но в контексте https://github.com/bitia-ru/gekkon-frontend/pull/223 кажется более разумным переделать фильтры на структуру вида:
filters = {
  categoryFrom: { defaultValue: ..., validator: () => ..., onlyForAuthorizedUsers: true/false},
  categoryTo: { defaultValue: ..., validator: () => ..., onlyForAuthorizedUsers: true/false},
  liked: .....
  flash: ....
  ...
}
и тогда решать отображать какой-то фильтр или нет по параметру onlyForAuthorizedUsers, это упростит добавление новых фильтров

Если предложение на такую переделку кажется разумным, тогда вопрос в рамках какого тикета ее лучше сделать?