### PR TITLE
GF-241: Невозможно создать трассу без фото

### DIFF
--- a/src/v2/components/RoutesEditModal/RoutesEditModal.js
+++ b/src/v2/components/RoutesEditModal/RoutesEditModal.js
@@ -233,7 +233,7 @@ class RoutesEditModal extends Component {
       }
       formData.append('route[category]', route.category);
     }
-    if (wallPhotoId || (routeProp.photo.url && route.photo === null)) {
+    if (wallPhotoId || (routeProp.photo?.url && route.photo === null)) {
       formData.append('route[wall_photo_id]', wallPhotoId);
     }
     if (photo.crop !== null) {


### PR DESCRIPTION
Это баг https://github.com/bitia-ru/gekkon-frontend/pull/219 ветки. Если попытаться создать трассу и не загрузить фото, то при нажатии на сохранить, в консоли вылетает ошибка и сохранения не происходит