### PR TITLE
GF-298: Убрать лишний скролл в окне задания положения трассы на схеме

### DIFF
--- a/src/v2/components/RoutesEditModal/RoutesEditModal.js
+++ b/src/v2/components/RoutesEditModal/RoutesEditModal.js
@@ -396,7 +396,15 @@ class RoutesEditModal extends Component {
     const iconImage = require('../../../../img/btn-handler/btn-handler-sprite.svg');
     return (
       <div className={css(styles.modalOverlayWrapper)}>
-        <div className={css(styles.modal, styles.modalOverlayModal)}>
+        <div
+          className={
+            css(
+              styles.modal,
+              styles.modalOverlayModal,
+              !schemeModalVisible && styles.modalFixHeight,
+            )
+          }
+        >
           <div className="modal-block__close">
             <CloseButton
               onClick={
@@ -687,13 +695,15 @@ const styles = StyleSheet.create({
     minHeight: '800px',
     minWidth: '960px',
     maxHeight: '1050px',
-    height: '95vh',
     '@media screen and (max-width: 1600px)': {
       minHeight: '700px',
     },
     '@media screen and (max-width: 1440px)': {
       minHeight: '600px',
     },
+  },
+  modalFixHeight: {
+    height: '95vh',
   },
   modalTrackBlock: {
     maxWidth: '530px',

--- a/src/v2/components/RoutesShowModal/RoutesShowModal.js
+++ b/src/v2/components/RoutesShowModal/RoutesShowModal.js
@@ -402,7 +402,15 @@ class RoutesShowModal extends Component {
 
     return (
       <div className={css(styles.modalOverlayWrapper)}>
-        <div className={css(styles.modal, styles.modalOverlayModal)}>
+        <div
+          className={
+            css(
+              styles.modal,
+              styles.modalOverlayModal,
+              !schemeModalVisible && styles.modalFixHeight,
+            )
+          }
+        >
           <div className="modal-block__close">
             <CloseButton
               onClick={
@@ -652,7 +660,7 @@ class RoutesShowModal extends Component {
                             text={route.description ? route.description : ''}
                           />
                         </div>
-                        <div className={css(styles.modalItem)}>
+                        <div className={css(styles.modalItem, styles.commentBlockWrapper)}>
                           <CommentBlock
                             startAnswer={this.startAnswer}
                             user={user}
@@ -768,13 +776,15 @@ const styles = StyleSheet.create({
     minHeight: '800px',
     minWidth: '960px',
     maxHeight: '1050px',
-    height: '95vh',
     '@media screen and (maxWidth: 1600px)': {
       minHeight: '700px',
     },
     '@media screen and (maxWidth: 1440px)': {
       minHeight: '600px',
     },
+  },
+  modalFixHeight: {
+    height: '95vh',
   },
   modalTrackBlock: {
     maxWidth: '530px',
@@ -958,6 +968,9 @@ const styles = StyleSheet.create({
     right: 'calc(100% + 12px)',
     top: '50%',
     transform: 'translateY(-50%)',
+  },
+  commentBlockWrapper: {
+    overflowY: 'auto',
   },
 });
 

--- a/src/v2/components/SchemeModal/SchemeModal.js
+++ b/src/v2/components/SchemeModal/SchemeModal.js
@@ -210,7 +210,7 @@ const styles = StyleSheet.create({
     position: 'relative',
     alignSelf: 'center',
     maxHeight: '100%',
-    overflowY: 'auto',
+    width: '100%',
     '> img': {
       width: '100%',
       maxWidth: '100%',


### PR DESCRIPTION
Проблема со скроллом возникает из-за того, что схема растягивается по горизонтали, а на размер окна по вертикали есть ограничения. В идеале надо сделать так, чтобы схема подстраивалась под размер окна по горизонтали или по вертикали, в зависимости от соотношения сторон, но такое решение потребует переделку логики расчета положения маркеров.
В качестве быстрого решения сделано так, что фиксированная высота для модального окна не задается в случае отображения схемы.
Попутно исправлено то, что при большом количестве комментариев, они отображаются за пределами модального окна